### PR TITLE
Fix #21: Prevent routers from adding themsevles as iBGP neighbours

### DIFF
--- a/src/RouterQuack.IO.Cisco/Utils/BgpConfig.cs
+++ b/src/RouterQuack.IO.Cisco/Utils/BgpConfig.cs
@@ -18,7 +18,10 @@ internal static class BgpConfig
         builder.AppendLine($" bgp router-id {router.Id}");
         builder.AppendLine(ConfigStart);
 
-        var ibgpNeighbours = router.ParentAs.Routers.ToArray();
+        var ibgpNeighbours = router.ParentAs.Routers
+            .Where(r => !r.Equals(router))
+            .ToArray();
+
         var ebgpNeighbours = router.Interfaces
             .Where(r => r.Bgp != BgpRelationship.None)
             .Select(i => i.Neighbour!)


### PR DESCRIPTION
## Description
Fix #21: Prevent routers from adding themsevles as iBGP neighbours.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [ ] Manual integration testing
- [ ] Verified on OS: ___________

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the XML documentation
- [x] My changes generate no new warnings