### PR TITLE
fix: IP loopback offsets weren't isolated to an AS

### DIFF
--- a/src/RouterQuack.Core/Processors/GenerateLoopbackAddresses.cs
+++ b/src/RouterQuack.Core/Processors/GenerateLoopbackAddresses.cs
@@ -16,47 +16,50 @@ public class GenerateLoopbackAddresses(
     public ILogger Logger { get; } = logger;
     public Context Context { get; } = context;
 
-    private UInt128 _addressCounter;
-    private HashSet<IPAddress> _usedAddresses = null!;
 
     public void Process()
     {
-        GenerateV4LoopbackAddresses();
-        GenerateV6LoopbackAddresses();
+        foreach (var @as in Context.Asses)
+        {
+            GenerateV4LoopbackAddresses(@as);
+            GenerateV6LoopbackAddresses(@as);
+        }
     }
 
-    private void GenerateV4LoopbackAddresses()
+    private void GenerateV4LoopbackAddresses(As @as)
     {
-        var routers = Context.Asses
-            .Where(a => a.AddressFamily.HasFlag(IpVersion.IPv4))
-            .SelectMany(a => a.Routers)
-            .Where(r => r is { External: false, LoopbackAddressV4: null });
+        if (!@as.AddressFamily.HasFlag(IpVersion.IPv4))
+            return;
 
-        _usedAddresses = Context.Asses
-            .SelectMany(a => a.Routers)
+        var routersToProcess = @as.Routers
+            .Where(r => r is { External: false, LoopbackAddressV4: null })
+            .ToArray();
+
+        // No space provided
+        if (routersToProcess.Any() && !routersToProcess[0].ParentAs.LoopbackSpaceV4.HasValue)
+        {
+            this.Log(@as, "Couldn't generate IPv4 loopback address (no loopback space defined in AS)");
+            return;
+        }
+
+        var usedAddresses = @as.Routers
             .Where(r => r.LoopbackAddressV4 != null)
             .Select(r => r.LoopbackAddressV4!)
             .ToHashSet();
 
-        _addressCounter = 1;
+        UInt128 addressCounter = 1;
 
-        foreach (var router in routers)
+        foreach (var router in routersToProcess)
         {
-            if (!router.ParentAs.LoopbackSpaceV4.HasValue)
-            {
-                this.Log(router, "Couldn't generate loopback address (no loopback space defined in AS)");
-                continue;
-            }
-
-            var space = router.ParentAs.LoopbackSpaceV4.Value;
+            var space = router.ParentAs.LoopbackSpaceV4!.Value;
             IPAddress ip;
             try
             {
-                ip = networkUtils.GenerateAvailableIpAddress(space, ref _addressCounter, _usedAddresses);
+                ip = networkUtils.GenerateAvailableIpAddress(space, ref addressCounter, usedAddresses);
             }
             catch (InvalidOperationException)
             {
-                this.Log(router.ParentAs, "Loopback space has overflowed");
+                this.Log(router.ParentAs, "Loopback space overflow");
                 return;
             }
 
@@ -66,39 +69,40 @@ public class GenerateLoopbackAddresses(
         }
     }
 
-    private void GenerateV6LoopbackAddresses()
+    private void GenerateV6LoopbackAddresses(As @as)
     {
-        var routers = Context.Asses
-            .Where(a => a.Core != CoreType.LDP)
-            .Where(a => a.AddressFamily.HasFlag(IpVersion.IPv6))
-            .SelectMany(a => a.Routers)
-            .Where(r => r is { External: false, LoopbackAddressV6: null });
+        if (!@as.AddressFamily.HasFlag(IpVersion.IPv6) || @as.Core.HasFlag(CoreType.LDP))
+            return;
 
-        _usedAddresses = Context.Asses
-            .SelectMany(a => a.Routers)
+        var routersToProcess = @as.Routers
+            .Where(r => r is { External: false, LoopbackAddressV6: null })
+            .ToArray();
+
+        // No space provided
+        if (routersToProcess.Any() && !routersToProcess[0].ParentAs.LoopbackSpaceV6.HasValue)
+        {
+            this.Log(@as, "Couldn't generate IPv6 loopback address (no loopback space defined in AS)");
+            return;
+        }
+
+        var usedAddresses = @as.Routers
             .Where(r => r.LoopbackAddressV6 != null)
             .Select(r => r.LoopbackAddressV6!)
             .ToHashSet();
 
-        _addressCounter = 1;
+        UInt128 addressCounter = 1;
 
-        foreach (var router in routers)
+        foreach (var router in routersToProcess)
         {
-            if (!router.ParentAs.LoopbackSpaceV6.HasValue)
-            {
-                this.Log(router, "Couldn't generate loopback address (no loopback space defined in AS)");
-                continue;
-            }
-
-            var space = router.ParentAs.LoopbackSpaceV6.Value;
+            var space = router.ParentAs.LoopbackSpaceV6!.Value;
             IPAddress ip;
             try
             {
-                ip = networkUtils.GenerateAvailableIpAddress(space, ref _addressCounter, _usedAddresses);
+                ip = networkUtils.GenerateAvailableIpAddress(space, ref addressCounter, usedAddresses);
             }
             catch (InvalidOperationException)
             {
-                this.Log(router.ParentAs, "Loopback space has overflowed");
+                this.Log(router.ParentAs, "Loopback space overflow");
                 return;
             }
 


### PR DESCRIPTION
## Description
The IP address counter for loopbacks affected other ASes. It would start at one, for the first AS only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Manual integration testing
- [ ] Verified on OS: ___________

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the XML documentation
- [ ] My changes generate no new warnings